### PR TITLE
Make cityscapescripts installable via pip so it can be used as requirement in other pkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Possible values of `split`
 
 ## Scripts
 
+Before using the scripts, make sure the following dependencies are installed:
+
+`sudo pip install numpy cython`
+
+`sudo apt install python-tk python-qt4`
+
 There are several scripts included with the dataset in a folder named `scripts`
  - `helpers`      helper files that are included by other scripts
  - `viewer`       view the images and the annotations

--- a/cityscapesscripts/viewer/cityscapesViewer.py
+++ b/cityscapesscripts/viewer/cityscapesViewer.py
@@ -17,7 +17,7 @@ import os
 # call processes
 import subprocess
 # copy things
-import copy 
+import copy
 # numpy
 import numpy as np
 # matplotlib for colormaps
@@ -607,7 +607,7 @@ class CityscapesViewer(QtGui.QMainWindow):
             overlay = self.drawLabels(qp)
             # Draw the label name next to the mouse
             self.drawLabelAtMouse(qp)
-        
+
         # Draw the zoom
         self.drawZoom(qp, overlay)
 
@@ -852,7 +852,7 @@ class CityscapesViewer(QtGui.QMainWindow):
     # Draw disparities
     def drawDisp( self , qp ):
         if not self.dispOverlay:
-            return 
+            return
 
         # Save QPainter settings to stack
         qp.save()
@@ -988,34 +988,34 @@ class CityscapesViewer(QtGui.QMainWindow):
 
         # Specify title
         dlgTitle = "Select new city"
-        message  = dlgTitle
+        message = dlgTitle
         question = dlgTitle
-        message  = "Select city for viewing"
+        message = "Select city for viewing"
         question = "Which city would you like to view?"
         self.statusBar().showMessage(message)
 
         if items:
+            # Create and wait for dialog
+            (item, ok) = QtGui.QInputDialog.getItem(self, dlgTitle, question,
+                                                    items, 0, False)
 
-		    # Create and wait for dialog
-		    (item, ok) = QtGui.QInputDialog.getItem(self, dlgTitle, question, items, 0, False)
+            # Restore message
+            self.statusBar().showMessage(restoreMessage)
 
-		    # Restore message
-		    self.statusBar().showMessage( restoreMessage )
-
-		    if ok and item:
-		        (split,gt,city) = [ str(i) for i in item.split(', ') ]
-		        if split == 'test' and not self.showDisparity:
-		            self.transp = 0.1
-		        else:
-		            self.transp = 0.5
-		        self.city      = os.path.normpath( os.path.join( csPath, "leftImg8bit" , split , city ) )
-		        self.labelPath = os.path.normpath( os.path.join( csPath, gt            , split , city ) )
-		        self.dispPath  = os.path.normpath( os.path.join( csPath, "disparity"   , split , city ) )
-		        self.loadCity()
-		        self.imageChanged()
+            if ok and item:
+                (split, gt, city) = [str(i) for i in item.split(', ')]
+                if split == 'test' and not self.showDisparity:
+                    self.transp = 0.1
+                else:
+                    self.transp = 0.5
+                self.city      = os.path.normpath(os.path.join(csPath, "leftImg8bit", split, city))
+                self.labelPath = os.path.normpath(os.path.join(csPath, gt           , split, city))
+                self.dispPath  = os.path.normpath(os.path.join(csPath, "disparity"  , split, city))
+                self.loadCity()
+                self.imageChanged()
 
         else:
- 
+
             warning = ""
             warning += "The data was not found. Please:\n\n"
             warning += " - make sure the scripts folder is in the Cityscapes root folder\n"
@@ -1023,20 +1023,20 @@ class CityscapesViewer(QtGui.QMainWindow):
             warning += " - set CITYSCAPES_DATASET to the Cityscapes root folder\n"
             warning += "       e.g. 'export CITYSCAPES_DATASET=<root_path>'\n"
 
-            reply = QtGui.QMessageBox.information(self, "ERROR!", warning, QtGui.QMessageBox.Ok)
+            reply = QtGui.QMessageBox.information(self, "ERROR!", warning,
+                                                  QtGui.QMessageBox.Ok)
             if reply == QtGui.QMessageBox.Ok:
                 sys.exit()
 
         return
 
-
     # Determine if the given candidate for a label path makes sense
-    def isLabelPathValid(self,labelPath):
+    def isLabelPathValid(self, labelPath):
         return os.path.isdir(labelPath)
 
     # Get the filename where to load labels
     # Returns empty string if not possible
-    def getLabelFilename( self ):
+    def getLabelFilename(self):
         # And we need to have a directory where labels should be searched
         if not self.labelPath:
             return ""
@@ -1048,10 +1048,10 @@ class CityscapesViewer(QtGui.QMainWindow):
             return ""
 
         # Generate the filename of the label file
-        filename = os.path.basename( self.currentFile )
-        filename = filename.replace( self.imageExt , self.gtExt )
-        filename = os.path.join( self.labelPath , filename )
-        search   = glob.glob( filename )
+        filename = os.path.basename(self.currentFile)
+        filename = filename.replace(self.imageExt, self.gtExt)
+        filename = os.path.join(self.labelPath, filename)
+        search   = glob.glob(filename)
         if not search:
             return ""
         filename = os.path.normpath(search[0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,51 @@
 # setup.py build_ext --inplace
 #
 # WARNING: Only tested for Ubuntu 64bit OS.
+import os
+from setuptools import setup
+has_cython = True
 
 try:
-    from distutils.core import setup
     from Cython.Build import cythonize
 except:
-    print("Unable to setup. Please use pip to install: cython")
+    print("Unable to find dependency cython. Please use pip to install: cython to get great speed improvements when evaluating")
     print("sudo pip install cython")
-import os
-import numpy
+    has_cython = False
 
-os.environ["CC"]  = "g++"
+include_dirs = []
+try:
+    import numpy as np
+    include_dirs = np.get_include()
+except:
+    print("Unable to find cython dependency numpy. Please use pip to install: numpy to get great speed improvements when evaluating")
+    print("sudo pip install numpy")
+
+os.environ["CC"] = "g++"
 os.environ["CXX"] = "g++"
 
-pyxFile = os.path.join( "cityscapesscripts" , "evaluation" , "addToConfusionMatrix.pyx" )
-setup(ext_modules = cythonize(pyxFile),include_dirs=[numpy.get_include()])
+pyxFile = os.path.join("cityscapesscripts", "evaluation", "addToConfusionMatrix.pyx")
+
+ext_modules = []
+if has_cython:
+    ext_modules = cythonize(pyxFile)
+
+config = {
+    'name': 'cityscapesscripts',
+    'description': 'The Cityscapes Dataset Scripts Repository',
+    'author': 'Marius Cordts',
+    'url': 'www.cityscapes-dataset.net',
+    'download_url': 'www.cityscapes-dataset.net',
+    'author_email': 'mail@cityscapes-dataset.net',
+    'version': '0.1',
+    'install_requires': ['numpy', 'matplotlib', 'cython', 'pillow'],
+    'packages': ['cityscapesscripts', 'cityscapesscripts.viewer', 'cityscapesscripts.annotation', 'cityscapesscripts.evaluation', 'cityscapesscripts.helpers'],
+    'scripts': [],
+    'entry_points': {'gui_scripts': ['viewer = cityscapesscripts.viewer.cityscapesViewer:main',
+                                     'labeltool = cityscapesscripts.annotation.cityscapesLabelTool:main']
+                     },
+    'package_data': {'': ['icons/*.png']},
+    'ext_modules': ext_modules,
+    'include_dirs': [include_dirs]
+}
+
+setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@
 # Run as
 # setup.py build_ext --inplace
 #
-# WARNING: Only tested for Ubuntu 64bit OS.
+# For MacOS X you may have to export the numpy headers in CFLAGS
+# export CFLAGS="-I /usr/local/lib/python3.6/site-packages/numpy/core/include $CFLAGS"
+
 import os
 from setuptools import setup
 has_cython = True


### PR DESCRIPTION
export & install viewer, labeler, evaluation, helpers so they can be used from outside packages
install shortcuts to /usr/local/bin
fix mixed tabs/spaces on cityscapesViewer that break python3 compability
add some dependencies to the readme