### PR TITLE
fix the precision value for the first point on the pr-rc curve

### DIFF
--- a/cityscapesscripts/evaluation/evalInstanceLevelSemanticLabeling.py
+++ b/cityscapesscripts/evaluation/evalInstanceLevelSemanticLabeling.py
@@ -521,7 +521,7 @@ def evaluateMatches(matches, args):
                         recall   [idxRes] = r
 
                     # first point in curve is artificial
-                    precision[-1] = 1.
+                    precision[-1] = precision[-2]
                     recall   [-1] = 0.
 
                     # compute average of precision-recall curve


### PR DESCRIPTION
Setting the precision value for recall=0 to 1 can lead to significant overestimation. The fewer points are on the curve the higher the impact. For typical proposal-based setups this is often not significant, however for proposal-free setups (which basically results in the curve having only a single point) this is significant.
In one of our experiments (real model trained on real data) this lead to an overestimation of 6 percentage points.

To fix it the precision at recall=0 should be set to the same precision as at the lowest recall value.