### PR TITLE
[Fix] Submit Link in README was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Note that all files have a small documentation at the top. Most important files
 ## Evaluation
 
 Once you want to test your method on the test set, please run your approach on the provided test images and submit your results:
-[Submission Page](www.cityscapes-dataset.com/submit)
+[Submission Page](https://cityscapes-dataset.com/submit)
 
 The result format is described at the top of our evaluation scripts:
 - [Pixel Level Semantic Labeling](cityscapesscripts/evaluation/evalPixelLevelSemanticLabeling.py)


### PR DESCRIPTION
Just replaced 'www.' with 'https://' as the Submit link was redirecting within GitHub internally and therefore not working.

Thanks for the work! Using the paper for my master thesis at TU Darmstadt and was really happy to see that it is from here. :)
Also pretty cool to look through the images of Darmstadt from 2015/2016.
Hope you are doing well! :)

Best Regards
Jonas