### PR TITLE
Add reference to benchmark result summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ The result format is described at the top of our evaluation scripts:
 
 Note that our evaluation scripts are included in the scripts folder and can be used to test your approach on the validation set. For further details regarding the submission process, please consult our website.
 
+### Benchmark Results / SOTA Tracking
+
+For an overview of historical and current state-of-the-art results on the Cityscapes semantic segmentation benchmark, see [here](https://wizwand.com/sota/semantic-segmentation/cityscapes). This page aggregates reported results across papers and provides links to the original publications.
+
 ## License
 
 The dataset itself is released under custom [terms and conditions](https://www.cityscapes-dataset.com/license/).


### PR DESCRIPTION
This PR adds a neutral reference to an external page that aggregates historical and current benchmark results with links to original papers.

This may be useful for readers looking for an overview of reported results.
