### PR TITLE
replace `np.in1d` with `np.isin`

### DIFF
--- a/cityscapesscripts/evaluation/evalInstanceLevelSemanticLabeling.py
+++ b/cityscapesscripts/evaluation/evalInstanceLevelSemanticLabeling.py
@@ -277,7 +277,7 @@ def assignGt2Preds(gtInstancesOrig, gtImage, predInfo, args):
     for label in labels:
         if label.ignoreInEval:
             voidLabelIDList.append(label.id)
-    boolVoid = np.in1d(gtNp, voidLabelIDList).reshape(gtNp.shape)
+    boolVoid = np.isin(gtNp, voidLabelIDList).reshape(gtNp.shape)
 
     # Loop through all prediction masks
     for predImageFile in predInfo:

--- a/cityscapesscripts/evaluation/evalPixelLevelSemanticLabeling.py
+++ b/cityscapesscripts/evaluation/evalPixelLevelSemanticLabeling.py
@@ -603,7 +603,7 @@ def evaluatePair(predictionImgFileName, groundTruthImgFileName, confMatrix, inst
         # Generate category masks
         categoryMasks = {}
         for category in instanceStats["categories"]:
-            categoryMasks[category] = np.in1d( predictionNp , instanceStats["categories"][category]["labelIds"] ).reshape(predictionNp.shape)
+            categoryMasks[category] = np.isin( predictionNp , instanceStats["categories"][category]["labelIds"] ).reshape(predictionNp.shape)
 
         instList = np.unique(instanceNp[instanceNp > 1000])
         for instId in instList:

--- a/cityscapesscripts/evaluation/evalPixelLevelSemanticLabeling.py
+++ b/cityscapesscripts/evaluation/evalPixelLevelSemanticLabeling.py
@@ -643,7 +643,7 @@ def evaluatePair(predictionImgFileName, groundTruthImgFileName, confMatrix, inst
 
     if args.evalPixelAccuracy:
         notIgnoredLabels = [l for l in args.evalLabels if not id2label[l].ignoreInEval]
-        notIgnoredPixels = np.in1d( groundTruthNp , notIgnoredLabels , invert=True ).reshape(groundTruthNp.shape)
+        notIgnoredPixels = np.isin( groundTruthNp , notIgnoredLabels , invert=True ).reshape(groundTruthNp.shape)
         erroneousPixels = np.logical_and( notIgnoredPixels , ( predictionNp != groundTruthNp ) )
         perImageStats[predictionImgFileName] = {}
         perImageStats[predictionImgFileName]["nbNotIgnoredPixels"] = np.count_nonzero(notIgnoredPixels)


### PR DESCRIPTION
`np.in1d` is removed in `numpy>=2.4`, replace it with `np.isin`.